### PR TITLE
fix-pack-caniuse-data-spawn-enoent

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -116,7 +116,7 @@ const tasks = new Listr([
     },
     {
         title: 'Packing caniuse data',
-        task: () => exec('babel-node', ['src/packer/index.js']),
+        task: () => exec('npx', ['babel-node', 'src/packer/index.js']),
         enabled,
     },
     {


### PR DESCRIPTION
Fix for the `spawn babel-node ENOENT` error in the publish js script. See this issue #42 
The problem was that the babel-node command was not resolved in the node_modules/.bin directory. Using npx to run the command resolves this issue
